### PR TITLE
Bind event handler to children directly

### DIFF
--- a/demo/index.js
+++ b/demo/index.js
@@ -18,8 +18,10 @@ const App = () => (
 
     <p>With react-isolated-scroll:</p>
 
-    <IsolatedScroll className="container">
-      <List />
+    <IsolatedScroll>
+      <div className="container">
+        <List />
+      </div>
     </IsolatedScroll>
 
     <p>Without react-isolated-scroll:</p>

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component, PropTypes, cloneElement, Children } from 'react';
 import isolatedScroll from 'isolated-scroll';
 
 const unbindHandlersKey = '__unbind_handlers__';
@@ -6,10 +6,7 @@ const unbindHandlersKey = '__unbind_handlers__';
 export default class IsolatedScroll extends Component {
 
   static propTypes = {
-    children: PropTypes.oneOfType([
-      PropTypes.arrayOf(PropTypes.node),
-      PropTypes.node
-    ])
+    children: PropTypes.node
   };
 
   constructor() {
@@ -35,11 +32,9 @@ export default class IsolatedScroll extends Component {
   render() {
     const { children } = this.props;
 
-    return (
-      <div ref={this.storeComponentReference} {...this.props}>
-        { children }
-      </div>
-    );
+    return cloneElement(Children.only(children), {
+      ref: this.storeComponentReference
+    });
   }
 
 }


### PR DESCRIPTION
Fixes #1 

This approach has the added benefit of not creating any extra DOM if it's not needed. The one drawback is that you can no longer support having multiple children but as we're wrapping with a div anyway that shouldn't really be a problem. Obviously introduces a breaking API change though.

Thoughts?
