### PR TITLE
Add prop-types to support recent React changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "isolated-scroll": "^0.1.0"
   },
   "peerDependencies": {
+    "prop-types": "^15.0.0",
     "react": "^0.14.0 || ^15.0.0-0"
   },
   "devDependencies": {
@@ -37,6 +38,7 @@
     "babel-register": "^6.11.6",
     "file-loader": "^0.9.0",
     "lodash.times": "^4.3.1",
+    "prop-types": "^15.5.8",
     "react": "^15.3.0",
     "react-dom": "^15.3.0",
     "webpack": "^1.13.1",

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import isolatedScroll from 'isolated-scroll';
 
 const unbindHandlersKey = '__unbind_handlers__';


### PR DESCRIPTION
As of React 15.5 React.PropTypes is depreciated.
https://facebook.github.io/react/docs/typechecking-with-proptypes.html

This causes a console.error call saying `Warning: Accessing PropTypes via the main React package is deprecated. Use the prop-types package from npm instead.`
This causes noise for consuming applications during development. The warning should not appear in production builds.

The recommended behavior is to use `prop-types` instead.
https://www.npmjs.com/package/prop-types